### PR TITLE
Configurando linters e formatadores

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -2,11 +2,11 @@
 # It is not intended for manual editing.
 
 [metadata]
-groups = ["default", "test"]
+groups = ["default", "test", "linter"]
 cross_platform = true
 static_urls = false
 lock_version = "4.3"
-content_hash = "sha256:e59590efeb09217397b8b1f34db53b292303cfe245ae152f72044e3105b6f7c2"
+content_hash = "sha256:a941c1468b42462934c92c2b5ab3b0c122baefabdc4cbacfc5ae9e2881944277"
 
 [[package]]
 name = "anyio"
@@ -24,6 +24,41 @@ files = [
 ]
 
 [[package]]
+name = "black"
+version = "22.1.0"
+requires_python = ">=3.6.2"
+summary = "The uncompromising code formatter."
+dependencies = [
+    "click>=8.0.0",
+    "mypy-extensions>=0.4.3",
+    "pathspec>=0.9.0",
+    "platformdirs>=2",
+    "tomli>=1.1.0",
+]
+files = [
+    {file = "black-22.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1297c63b9e1b96a3d0da2d85d11cd9bf8664251fd69ddac068b98dc4f34f73b6"},
+    {file = "black-22.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2ff96450d3ad9ea499fc4c60e425a1439c2120cbbc1ab959ff20f7c76ec7e866"},
+    {file = "black-22.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e21e1f1efa65a50e3960edd068b6ae6d64ad6235bd8bfea116a03b21836af71"},
+    {file = "black-22.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e2f69158a7d120fd641d1fa9a921d898e20d52e44a74a6fbbcc570a62a6bc8ab"},
+    {file = "black-22.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:228b5ae2c8e3d6227e4bde5920d2fc66cc3400fde7bcc74f480cb07ef0b570d5"},
+    {file = "black-22.1.0-py3-none-any.whl", hash = "sha256:3524739d76b6b3ed1132422bf9d82123cd1705086723bc3e235ca39fd21c667d"},
+    {file = "black-22.1.0.tar.gz", hash = "sha256:a7c0192d35635f6fc1174be575cb7915e92e5dd629ee79fdaf0dcfa41a80afb5"},
+]
+
+[[package]]
+name = "blue"
+version = "0.9.1"
+summary = "Blue -- Some folks like black but I prefer blue."
+dependencies = [
+    "black==22.1.0",
+    "flake8<5.0.0,>=3.8",
+]
+files = [
+    {file = "blue-0.9.1-py3-none-any.whl", hash = "sha256:037742c072c58a2ff024f59fb9164257b907f97f8f862008db3b013d1f27cc22"},
+    {file = "blue-0.9.1.tar.gz", hash = "sha256:76b4f26884a8425042356601d80773db6e0e14bebaa7a59d7c54bf8cef2e2af5"},
+]
+
+[[package]]
 name = "certifi"
 version = "2023.7.22"
 requires_python = ">=3.6"
@@ -31,6 +66,19 @@ summary = "Python package for providing Mozilla's CA Bundle."
 files = [
     {file = "certifi-2023.7.22-py3-none-any.whl", hash = "sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"},
     {file = "certifi-2023.7.22.tar.gz", hash = "sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082"},
+]
+
+[[package]]
+name = "click"
+version = "8.1.7"
+requires_python = ">=3.7"
+summary = "Composable command line interface toolkit"
+dependencies = [
+    "colorama; platform_system == \"Windows\"",
+]
+files = [
+    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
+    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
 ]
 
 [[package]]
@@ -85,6 +133,21 @@ summary = "Backport of PEP 654 (exception groups)"
 files = [
     {file = "exceptiongroup-1.1.2-py3-none-any.whl", hash = "sha256:e346e69d186172ca7cf029c8c1d16235aa0e04035e5750b4b95039e65204328f"},
     {file = "exceptiongroup-1.1.2.tar.gz", hash = "sha256:12c3e887d6485d16943a309616de20ae5582633e0a2eda17f4e10fd61c1e8af5"},
+]
+
+[[package]]
+name = "flake8"
+version = "4.0.1"
+requires_python = ">=3.6"
+summary = "the modular source code checker: pep8 pyflakes and co"
+dependencies = [
+    "mccabe<0.7.0,>=0.6.0",
+    "pycodestyle<2.9.0,>=2.8.0",
+    "pyflakes<2.5.0,>=2.4.0",
+]
+files = [
+    {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
+    {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
 ]
 
 [[package]]
@@ -150,6 +213,16 @@ files = [
 ]
 
 [[package]]
+name = "isort"
+version = "5.12.0"
+requires_python = ">=3.8.0"
+summary = "A Python utility / library to sort Python imports."
+files = [
+    {file = "isort-5.12.0-py3-none-any.whl", hash = "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"},
+    {file = "isort-5.12.0.tar.gz", hash = "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504"},
+]
+
+[[package]]
 name = "lxml"
 version = "4.9.3"
 requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, != 3.4.*"
@@ -197,6 +270,25 @@ files = [
 ]
 
 [[package]]
+name = "mccabe"
+version = "0.6.1"
+summary = "McCabe checker, plugin for flake8"
+files = [
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+requires_python = ">=3.5"
+summary = "Type system extensions for programs checked with the mypy type checker."
+files = [
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+]
+
+[[package]]
 name = "packaging"
 version = "23.1"
 requires_python = ">=3.7"
@@ -207,6 +299,26 @@ files = [
 ]
 
 [[package]]
+name = "pathspec"
+version = "0.11.2"
+requires_python = ">=3.7"
+summary = "Utility library for gitignore style pattern matching of file paths."
+files = [
+    {file = "pathspec-0.11.2-py3-none-any.whl", hash = "sha256:1d6ed233af05e679efb96b1851550ea95bbb64b7c490b0f5aa52996c11e92a20"},
+    {file = "pathspec-0.11.2.tar.gz", hash = "sha256:e0d8d0ac2f12da61956eb2306b69f9469b42f4deb0f3cb6ed47b9cce9996ced3"},
+]
+
+[[package]]
+name = "platformdirs"
+version = "3.10.0"
+requires_python = ">=3.7"
+summary = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+files = [
+    {file = "platformdirs-3.10.0-py3-none-any.whl", hash = "sha256:d7c24979f292f916dc9cbf8648319032f551ea8c49a4c9bf2fb556a02070ec1d"},
+    {file = "platformdirs-3.10.0.tar.gz", hash = "sha256:b45696dab2d7cc691a3226759c0d3b00c47c8b6e293d96f6436f733303f77f6d"},
+]
+
+[[package]]
 name = "pluggy"
 version = "1.2.0"
 requires_python = ">=3.7"
@@ -214,6 +326,26 @@ summary = "plugin and hook calling mechanisms for python"
 files = [
     {file = "pluggy-1.2.0-py3-none-any.whl", hash = "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849"},
     {file = "pluggy-1.2.0.tar.gz", hash = "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"},
+]
+
+[[package]]
+name = "pycodestyle"
+version = "2.8.0"
+requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+summary = "Python style guide checker"
+files = [
+    {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
+    {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
+]
+
+[[package]]
+name = "pyflakes"
+version = "2.4.0"
+requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+summary = "passive checker of Python programs"
+files = [
+    {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
+    {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,3 @@
-[tool.pdm]
-[tool.pdm.scripts]
-test_all.cmd = "pytest -vv -s"
-test_all.env_file = '.env'
-
-test.cmd = "pytest -vv -s -k test_ -k 'not test_action'"
-test.env_file = '.env'
-
-[tool.pdm.dev-dependencies]
-test = [
-    "pytest>=7.3.1",
-]
-
 [project]
 name = "tasker.py"
 version = "0.2.0"
@@ -27,3 +14,28 @@ dependencies = [
 
 requires-python = ">=3.10"
 license = {text = "MIT"}
+
+
+[tool.pdm.scripts]
+test_all.cmd = "pytest -vv -s"
+test_all.env_file = ".env"
+
+test.cmd = "pytest -vv -s -k test_ -k 'not test_action'"
+test.env_file = ".env"
+
+lint.shell = "blue --check --diff . && isort --check --diff ."
+format.shell = "blue . && isort ."
+
+[tool.pdm.dev-dependencies]
+test = [
+    "pytest>=7.3.1",
+]
+
+linter = [
+    "blue>=0.9.1",
+    "isort>=5.12.0",
+]
+
+[tool.isort]
+profile = "black"
+line_length = 79

--- a/src/tasker/actions/alert/beep.py
+++ b/src/tasker/actions/alert/beep.py
@@ -1,11 +1,12 @@
 from dataclasses import dataclass
 
-from tasker.py import Action
 from tasker import Stream
+from tasker.py import Action
+
 
 @dataclass
 class Beep(Action):
-    _code_ = 171 
+    _code_ = 171
 
     frequency: int = 8000
     duration: int = 1000

--- a/src/tasker/actions/alert/morse.py
+++ b/src/tasker/actions/alert/morse.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass
 
-from tasker.py import Action
 from tasker import Stream
+from tasker.py import Action
+
 
 @dataclass
 class Morse(Action):

--- a/src/tasker/actions/alert/notify.py
+++ b/src/tasker/actions/alert/notify.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 
 from tasker.py import Action
 
+
 @dataclass
 class Notify(Action):
     title: str

--- a/src/tasker/actions/alert/notify_cancel.py
+++ b/src/tasker/actions/alert/notify_cancel.py
@@ -2,11 +2,6 @@ from tasker.py import Action
 
 
 class NotifyCancel(Action):
-    def __init__(
-            self,
-            title = None,
-            warn_not_exist = False
-        ):
-            self.title = title
-            self.warn_not_exist = warn_not_exist
-
+    def __init__(self, title=None, warn_not_exist=False):
+        self.title = title
+        self.warn_not_exist = warn_not_exist

--- a/src/tasker/actions/alert/say.py
+++ b/src/tasker/actions/alert/say.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
-from tasker.py import Action
 from tasker import Stream
+from tasker.py import Action
 
 
 @dataclass

--- a/src/tasker/app_info.py
+++ b/src/tasker/app_info.py
@@ -4,11 +4,6 @@ from .env import Env
 
 
 class AppInfo(str, Enum):
-    PACKAGE = (
-        'net.dinglisch.android.taskerm'
-        or
-        Env().TASKER_PY_PACKAGE
-    )
+    PACKAGE = 'net.dinglisch.android.taskerm' or Env().TASKER_PY_PACKAGE
 
     RESOURCE = f'android.resource://{PACKAGE}/drawable'
-

--- a/src/tasker/env.py
+++ b/src/tasker/env.py
@@ -1,5 +1,4 @@
 from dataclasses import asdict, dataclass
-
 from os import getenv
 
 

--- a/src/tasker/icons/__init__.py
+++ b/src/tasker/icons/__init__.py
@@ -1,1 +1,1 @@
-from  .misc import Misc
+from .misc import Misc

--- a/src/tasker/icons/icon.py
+++ b/src/tasker/icons/icon.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 
 from ..app_info import AppInfo
 

--- a/src/tasker/icons/misc.py
+++ b/src/tasker/icons/misc.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+
 from .icon import Icon
 
 

--- a/src/tasker/py/__init__.py
+++ b/src/tasker/py/__init__.py
@@ -1,4 +1,3 @@
-from .main import TaskerPy
-
-from .task import Task
 from .action import Action
+from .main import TaskerPy
+from .task import Task

--- a/src/tasker/py/client.py
+++ b/src/tasker/py/client.py
@@ -3,10 +3,10 @@ from httpx import Client
 
 class TaskerPyClient(Client):
     def __init__(
-            self,
-            address = 'localhost',
-            port = 9170,
-        ):
+        self,
+        address='localhost',
+        port=9170,
+    ):
 
         super().__init__(
             base_url=f'http://{address}:{port}',

--- a/src/tasker/py/main.py
+++ b/src/tasker/py/main.py
@@ -1,12 +1,11 @@
+from dataclasses import dataclass
 from os import getenv
 from random import randint
-from dataclasses import dataclass
 
 from .client import TaskerPyClient
-
 from .profile import Profile
-from .task import Task
 from .scene import Scene
+from .task import Task
 
 
 @dataclass
@@ -15,35 +14,32 @@ class TaskerPy:
     port: int = 9170
 
     def __post_init__(self):
-        self._client = TaskerPyClient(
-            self.address,
-            self.port
-        )
+        self._client = TaskerPyClient(self.address, self.port)
 
         self._profiles: list[Profile] = []
         self._tasks: list[Task] = []
         self._scenes: list[Scene] = []
 
     def _generate_id(
-            self,
-            items: list[Profile] | list[Task] | list[Scene],
-            randint_args = [1_000, 100_000],
-        ) -> int:
+        self,
+        items: list[Profile] | list[Task] | list[Scene],
+        randint_args=[1_000, 100_000],
+    ) -> int:
         new_id = randint(*randint_args)
 
         if any((new_id == item.id for item in items)):
             return self._generate_id(items, randint_args)
-        
+
         return new_id
 
-
     def add_task(
-            self,
-            name: str | None = None,
-            task_id: int = None,
-            returned: dict[str, str] = None
-        ):
-        if task_id is None: task_id = self._generate_id(self._tasks)
+        self,
+        name: str | None = None,
+        task_id: int | None = None,
+        returned: dict[str, str] | None = None,
+    ):
+        if task_id is None:
+            task_id = self._generate_id(self._tasks)
 
         def decorator(action_func):
             task = Task(

--- a/src/tasker/py/scene.py
+++ b/src/tasker/py/scene.py
@@ -3,4 +3,5 @@ from dataclasses import dataclass
 
 @dataclass
 class Scene:
-        ...
+    id: int
+    ...

--- a/src/tasker/py/task.py
+++ b/src/tasker/py/task.py
@@ -1,15 +1,14 @@
+from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Generator
-from copy import deepcopy
 
 from lxml import etree
 
+from ..task_collision import TaskCollision
 from ..xml_utils import XmlUtils
 from .action import Action
-from ..task_collision import TaskCollision
 from .client import TaskerPyClient
-
 
 LOCAL_TASKS = '/sdcard/Tasker/tasks/'
 
@@ -20,19 +19,16 @@ class Task:
     name: str
 
     _actions: Callable[..., Generator[Action, None, None]]
-    _returned: dict[str, str]
+    _returned: dict[str, str] | None
     _client: TaskerPyClient
 
     priority: int = 100
-    collision: TaskCollision = (
-        TaskCollision.ABORT_NEW_TASK
-    )
+    collision: TaskCollision = TaskCollision.ABORT_NEW_TASK
 
     par1: Any = None
     par2: Any = None
 
     variables: dict[str, Any] = field(default_factory=dict)
-
 
     def __call__(self, *args, **kwargs):
         for action in self._actions(self):
@@ -41,18 +37,12 @@ class Task:
     def to_string(self):
         xml_utils = XmlUtils()
 
-        xml_task = xml_utils.create_task(
-            self.id,
-            self.name,
-            *self()
-        )
+        xml_task = xml_utils.create_task(self.id, self.name, *self())
 
         return etree.tostring(xml_task).decode()
 
     def export(self, directory: str | Path = LOCAL_TASKS):
-        filepath = (
-            Path(directory) / f'{self.name}.tsk.xml'
-        )
+        filepath = Path(directory) / f'{self.name}.tsk.xml'
 
         xml_string = self.to_string()
         filepath.write_text(xml_string)
@@ -61,16 +51,14 @@ class Task:
     def play(self):
         body = {
             'task_xml': self.to_string(),
-
             'task_name': self.name,
             'par1': self.par1,
             'par2': self.par2,
-
             'response_schema': {
                 'status_code': 200,
                 'headers': 'host:tasker.py',
-                'body': self._returned
-            }
+                'body': self._returned,
+            },
         }
 
         return self._client.post('/run', json=body).json()

--- a/src/tasker/stream.py
+++ b/src/tasker/stream.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
+
 class Stream(int, Enum):
     CALL = 0
     SYSTEM = 1
@@ -7,4 +8,3 @@ class Stream(int, Enum):
     MEDIA = 3
     ALARM = 4
     NOTIFICATION = 5
-

--- a/src/tasker/xml_utils.py
+++ b/src/tasker/xml_utils.py
@@ -7,50 +7,42 @@ from .stream import Stream
 
 
 class XmlUtils:
-   def _create_data(self, *datas: E):
-      return E.TaskerData(*datas, sr="", dvi="1")
-   
-   def _action_to_args(self, action: Action):
-      action_args = astuple(action)
+    def _create_data(self, *datas: E):
+        return E.TaskerData(*datas, sr='', dvi='1')
 
-      for index, value in enumerate(action_args):
-            kwargs = {'sr': f"arg{index}"}
+    def _action_to_args(self, action: Action):
+        action_args = astuple(action)
+
+        for index, value in enumerate(action_args):
+            kwargs = {'sr': f'arg{index}'}
 
             match value:
-               case Stream():
-                  int_stream = int(value)
-                  yield E.Int(**kwargs, val=str(int_stream))
-               case int():
-                  yield E.Int(**kwargs, val=str(value))
-               case str():
-                  yield E.Str(**kwargs, val=str(value))
+                case Stream():
+                    int_stream = int(value)
+                    yield E.Int(**kwargs, val=str(int_stream))
+                case int():
+                    yield E.Int(**kwargs, val=str(value))
+                case str():
+                    yield E.Str(**kwargs, val=str(value))
 
-   def _actions_to_xml(self, *actions: Action):
-      for index, action in enumerate(actions):
-         yield E.Action(
-               E.code(f'{action._code_}'),
-               *self._action_to_args(action),
-
-               sr=f"act{index}",
-               ve="7"
-         )                    
-
-
-   def create_task(
-            self,
-            task_id: int,
-            task_name: str,
-            *actions: Action
-         ):
-      return self._create_data(
-            E.Task(
-               E.cdate("0"),
-               E.edate("1"),
-               E.id(f'{task_id}'),
-               E.nme(task_name),
-               E.pri("100"),
-               *self._actions_to_xml(*actions),
-
-               sr="task"
+    def _actions_to_xml(self, *actions: Action):
+        for index, action in enumerate(actions):
+            yield E.Action(
+                E.code(f'{action._code_}'),
+                *self._action_to_args(action),
+                sr=f'act{index}',
+                ve='7',
             )
-         )
+
+    def create_task(self, task_id: int, task_name: str, *actions: Action):
+        return self._create_data(
+            E.Task(
+                E.cdate('0'),
+                E.edate('1'),
+                E.id(f'{task_id}'),
+                E.nme(task_name),
+                E.pri('100'),
+                *self._actions_to_xml(*actions),
+                sr='task',
+            )
+        )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,6 @@
 from os import getenv
 
-from pytest import mark, Function
+from pytest import Function, mark
 
 
 def pytest_collection_modifyitems(session, config, items: list[Function]):

--- a/test/test_action.py
+++ b/test/test_action.py
@@ -1,13 +1,11 @@
-from tasker.py import TaskerPy, Task
 from tasker.actions.alert import Beep
+from tasker.py import Task, TaskerPy
 
 
 def test_beep():
     app = TaskerPy()
 
-    variables_returned = {
-        'var': r'%par1'
-    }
+    variables_returned = {'var': r'%par1'}
 
     @app.add_task('TPY - Run', returned=variables_returned)
     def task(t: Task):

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -4,13 +4,9 @@ from tasker.env import Env
 
 
 def test_TASKER_PY_PACKAGE_é_uma_variavel_de_ambiente(
-        monkeypatch: MonkeyPatch
-    ):
+    monkeypatch: MonkeyPatch,
+):
 
-    monkeypatch.setenv(
-        'TASKER_PY_PACKAGE',
-        'com.taskerpy'
-    )
-
+    monkeypatch.setenv('TASKER_PY_PACKAGE', 'com.taskerpy')
 
     assert Env().TASKER_PY_PACKAGE == 'com.taskerpy'

--- a/test/test_tasker.py
+++ b/test/test_tasker.py
@@ -1,9 +1,10 @@
-from pathlib import Path
 from dataclasses import dataclass
+from pathlib import Path
+
 from pytest import fixture
 
-from tasker.py import TaskerPy, Task
 from tasker.actions.alert import Beep
+from tasker.py import Task, TaskerPy
 
 
 @fixture
@@ -30,7 +31,6 @@ def test_criar_tarefa_e_ações(app: TaskerPy):
         Beep(4000, duration=100),
     ]
 
-
     @app.add_task('Task Name')
     def task(t: Task):
         beep = Beep(1000, duration=100)
@@ -39,7 +39,6 @@ def test_criar_tarefa_e_ações(app: TaskerPy):
         for _ in range(3):
             beep.frequency += 1000
             yield beep
-
 
     assert isinstance(task, Task)
     assert task.name == 'Task Name'
@@ -68,7 +67,7 @@ def test__generate_id(app: TaskerPy):
 def test_iterar_2_vezes_a_mesma_tarefa(app: TaskerPy):
     expected_actions = [
         Beep(frequency=1000, duration=100),
-        Beep(frequency=2000, duration=100)
+        Beep(frequency=2000, duration=100),
     ]
 
     @app.add_task(name='2_task')

--- a/test/test_xml_utils.py
+++ b/test/test_xml_utils.py
@@ -1,30 +1,27 @@
 from lxml import etree
 
-from tasker.xml_utils import XmlUtils
 from tasker.actions.alert import Beep
+from tasker.xml_utils import XmlUtils
 
-
-TASK_XML = (
-"""
+TASK_XML = """
 <TaskerData sr="" dvi="1">
-	<Task sr="task">
-		<cdate>0</cdate>
-		<edate>1</edate>
-		<id>1</id>
-		<nme>task_test</nme>
-		<pri>100</pri>
-		<Action sr="act0" ve="7">
-			<code>171</code>
-			<Int sr="arg0" val="8000"/>
-			<Int sr="arg1" val="1000"/>
-			<Int sr="arg2" val="50"/>
-			<Int sr="arg3" val="3"/>
-			<Str sr="arg4" val=""/>
-		</Action>
-	</Task>
+    <Task sr="task">
+        <cdate>0</cdate>
+        <edate>1</edate>
+        <id>1</id>
+        <nme>task_test</nme>
+        <pri>100</pri>
+        <Action sr="act0" ve="7">
+            <code>171</code>
+            <Int sr="arg0" val="8000"/>
+            <Int sr="arg1" val="1000"/>
+            <Int sr="arg2" val="50"/>
+            <Int sr="arg3" val="3"/>
+            <Str sr="arg4" val=""/>
+        </Action>
+    </Task>
 </TaskerData>
 """
-)
 
 
 parser = etree.XMLParser(remove_blank_text=True)
@@ -35,8 +32,6 @@ def test_task_xml_creator():
     xml_task = xml_utils.create_task(1, 'task_test', Beep())
     xml_string = etree.tostring(xml_task)
 
-    xml_expected = etree.tostring(
-        etree.fromstring(TASK_XML, parser)
-    )
+    xml_expected = etree.tostring(etree.fromstring(TASK_XML, parser))
 
     assert xml_string == xml_expected


### PR DESCRIPTION
- **blue** - segue a pep8 e usa aspas simples
- **isort** - formata import em ordem alfabética
- scripts adicionados:
    - `pdm run format`
    - `pdm run lint`
- arquivo do projeto e teste formandos

> Obs: gostaria de usar o **ruff** ou **pylint**, mas o **ruff** não é compatível com arquitetura de celular

#4 